### PR TITLE
Feature - GET most viewed Solana meme tokens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,4 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+/appsettings.json

--- a/Bot.cs
+++ b/Bot.cs
@@ -41,15 +41,16 @@ namespace SolMemeDiscordBot
             {
                 Console.WriteLine($"Received message: {message.Content ?? String.Empty}");
                 {
-                    if (message.Content.ToLower() == "yo")
+                    string[] greetings = new string[] { "Hey", "Hello", "Hi", "Wassup", "Waddup", "Howdy", "Yo", "You called?" };
+                   
+                    if (message.Content.ToLower().Contains("hi"))
                     {
-                        string[] greetings = new string[] { "Hey", "Hello", "Hi", "Wassup", "Waddup", "Howdy", "Yo", "You called?" };
                         Random random = new Random();
                         int index = random.Next(greetings.Length);
 
                         await ReplyAsync(message, $"{greetings[index]} {message.Author.GlobalName}!");
                     }
-                    else if (message.Content.ToLower().Contains("get tokens"))
+                    else if (message.Content.ToLower().Contains("get-tokens"))
                     {
                         string response = "Here are the MOST viewed tokens at this very moment:\n";
                         RugCheck rugCheck = new RugCheck();

--- a/RugCheck.cs
+++ b/RugCheck.cs
@@ -18,7 +18,7 @@ namespace SolMemeDiscordBot
 
         public async Task<string> GetMostViewedTokens()
         {
-            string result = "I'm unable to retrieve that info at the moment. Try again later.";
+            string result = String.Empty;
 
             using var client = new HttpClient();
 
@@ -31,17 +31,28 @@ namespace SolMemeDiscordBot
                     string content = await response.Content.ReadAsStringAsync();
                     dynamic data = JsonConvert.DeserializeObject(content);
 
+                    foreach (var token in data)
+                    {
+                        result += $"{token.metadata.name} ({token.metadata.symbol})\n";
+                        result += $"User Visits: {token.user_visits}\n";
+                        result += $"Visits: {token.visits}\n";
+                        result += $"Score: {token.score}\n";
+                        result += $"https://gmgn.ai/sol/token/{token.mint}\n\n";
+                    }
 
 
+                    return result;
                 }
                 else
                 {
                     Console.WriteLine($"Network Error: {response.StatusCode}");
+                    result = "I'm unable to retrieve that info at the moment. Try again later.";
                 }
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Exception: {ex.Message}");
+                result = "I'm unable to retrieve that info at the moment. Try again later.";
             }
 
             return result;

--- a/SolMemeDiscordBot.csproj
+++ b/SolMemeDiscordBot.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Discord.Net" Version="3.17.2" />
+		<PackageReference Include="Discord.Net.Commands" Version="3.17.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,3 +1,0 @@
-{
-  "Discord_Token": "YOUR_DISCORD_TOKEN"
-}


### PR DESCRIPTION
#Changes.
- Solana meme tokens are pulled from rugcheck api (most viewed).
- Messaging the bot with a message reading "get-tokens" , will result in the bot responding with the most viewed Solana tokens at that moment. 
- Token data includes the following:
1) Mint address
2) Name
3) Symbol
4) Views 
5) User Views
6) GMGN url

#Notes: There is so much work to do here from validations, to making sure only tokens with mint authority revoked are retrieved, along with other important things. 

At the moment it is only text based messaging. This feature will have to be upgraded to a command.